### PR TITLE
API requires that the manifest name matches the pypi package name

### DIFF
--- a/lambda_packages/__init__.py
+++ b/lambda_packages/__init__.py
@@ -26,7 +26,7 @@ lambda_packages = {
         'version': '2.6.1',
         'path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'psycopg2', 'psycopg2-2.6.1.tar.gz')
     },
-    'Crypto': {
+    'pycrypto': {
         'version': '2.6.1',
         'path': os.path.join(os.path.dirname(os.path.abspath(__file__)),
                              'pycrypto', 'pycrypto-2.6.1.tar.gz')


### PR DESCRIPTION
#9, #10 