### PR TITLE
Temporary venv now works.

### DIFF
--- a/lambda_packages/PyNaCl/build.sh
+++ b/lambda_packages/PyNaCl/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-PACKAGE=$1
-VERSION=$2
-TMP_DIR="$PACKAGE_$VERSION"
+PACKAGE=${1}
+VERSION=${2}
+TMP_DIR="${PACKAGE}_${VERSION}"
 
-mkdir $TMP_DIR
-cd  $TMP_DIR
-echo "Packaging $PACKAGE"
+mkdir ${TMP_DIR}
+cd  ${TMP_DIR}
+echo "Packaging ${PACKAGE}"
 
 echo "do update"
 sudo yum update -y
@@ -17,13 +17,13 @@ echo "do dependcy install"
 
 yum install -y libffi libffi-devel openssl openssl-devel
 
-ENV="env-$PACKAGE-$VERSION"
+ENV="env-${PACKAGE}-${VERSION}"
 
-echo "make $ENV"
-/usr/bin/virtualenv "$ENV"
+echo "make ${ENV}"
+virtualenv "${ENV}"
 
 echo "activate env in `pwd`"
-source "$ENV/bin/activate"
+source "${ENV}/bin/activate"
 
 # https://github.com/pypa/pip/issues/3056
 echo '[install]' > ./setup.cfg
@@ -32,11 +32,11 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target $TARGET_DIR "$PACKAGE==$VERSION"
+pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
-cd $TARGET_DIR && tar -zcvf ../../../$PACKAGE-$VERSION.tar.gz * && cd ../../..
-rm -rf $TMP_DIR
+cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..
+rm -rf ${TMP_DIR}
 
 
 

--- a/lambda_packages/cffi/build.sh
+++ b/lambda_packages/cffi/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-PACKAGE=$1
-VERSION=$2
-TMP_DIR="$PACKAGE_$VERSION"
+PACKAGE=${1}
+VERSION=${2}
+TMP_DIR="${PACKAGE}_${VERSION}"
 
-mkdir $TMP_DIR
-cd  $TMP_DIR
-echo "Packaging $PACKAGE"
+mkdir ${TMP_DIR}
+cd  ${TMP_DIR}
+echo "Packaging ${PACKAGE}"
 
 echo "do update"
 sudo yum update -y
@@ -17,13 +17,13 @@ echo "do dependcy install"
 
 yum install -y libffi libffi-devel openssl openssl-devel
 
-ENV="env-$PACKAGE-$VERSION"
+ENV="env-${PACKAGE}-${VERSION}"
 
-echo "make $ENV"
-/usr/bin/virtualenv "$ENV"
+echo "make ${ENV}"
+virtualenv "${ENV}"
 
 echo "activate env in `pwd`"
-source "$ENV/bin/activate"
+source "${ENV}/bin/activate"
 
 # https://github.com/pypa/pip/issues/3056
 echo '[install]' > ./setup.cfg
@@ -32,11 +32,11 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target $TARGET_DIR "$PACKAGE==$VERSION"
+pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
-cd $TARGET_DIR && tar -zcvf ../../../$PACKAGE-$VERSION.tar.gz * && cd ../../..
-rm -rf $TMP_DIR
+cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..
+rm -rf ${TMP_DIR}
 
 
 


### PR DESCRIPTION
This PR is is not critical, but does address some minor issues with the build.sh script (which may be successfully used to compile other c-extension based packages as well)

* Use exlicit bash variable to avoid unwanted bash parameter expansions (e.g. in case of '\_' used in  `${PACKAGE}_${VERSION}`)
* It seems the virtualenv script location varies (on 'ami-48d38c2b') it's `/usr/local/bin`. Relying on `virtualenv` being available on the ami image seems to be more reliable than explicitly trying to guess its location. 