### PR TITLE
[Fix] Not showing "`pwd`" script code

### DIFF
--- a/lambda_packages/mysqlclient/README.md
+++ b/lambda_packages/mysqlclient/README.md
@@ -6,6 +6,10 @@ On an machine with Amazon Linux:
 
 On a machine with docker and access to lambci images:
 
-`docker run --rm -v `pwd`:/app lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only mysqlclient 1.3.12"`
+```
+docker run --rm -v `pwd`:/app lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only mysqlclient 1.3.12"
+```
 
-`docker run --rm -v `pwd`:/app lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only mysqlclient 1.3.12"`
+```
+docker run --rm -v `pwd`:/app lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only mysqlclient 1.3.12"
+```


### PR DESCRIPTION
As Github Markdown previewer treats "\`" as an inline-code block, inner code \`pwd\` is used as an end of the code block and creates a new code block.
So "``` code block" would be better to use.