### PR TITLE
Remove '--use-wheel' from pip; fix README formatting

### DIFF
--- a/lambda_packages/Pillow/README.md
+++ b/lambda_packages/Pillow/README.md
@@ -15,7 +15,7 @@ The EC2 instance will need the correct IAM role to perform this action.
 
 ##Build
 
-Report from `pip install --verbose --use-wheel pillow`
+Report from `pip install --verbose pillow`
 
 ```
 

--- a/lambda_packages/Pillow/build.sh
+++ b/lambda_packages/Pillow/build.sh
@@ -39,7 +39,7 @@ echo "activate env in `pwd`"
 source env/bin/activate
 
 echo "install pips"
-pip install --verbose --use-wheel Pillow==${PILVER}
+pip install --verbose Pillow==${PILVER}
 deactivate
 
 echo "tar lib and lib64"

--- a/lambda_packages/PyNaCl/build.sh
+++ b/lambda_packages/PyNaCl/build.sh
@@ -32,7 +32,7 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+pip install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
 cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..

--- a/lambda_packages/bcrypt/build.sh
+++ b/lambda_packages/bcrypt/build.sh
@@ -32,7 +32,7 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+pip install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
 cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..

--- a/lambda_packages/cffi/build.sh
+++ b/lambda_packages/cffi/build.sh
@@ -32,7 +32,7 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+pip install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
 cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..

--- a/lambda_packages/misaka/build.sh
+++ b/lambda_packages/misaka/build.sh
@@ -32,7 +32,7 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+pip install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
 cd ${TARGET_DIR} && tar -zcvf ../../../${PACKAGE}-${VERSION}.tar.gz * && cd ../../..

--- a/lambda_packages/mysqlclient/README.md
+++ b/lambda_packages/mysqlclient/README.md
@@ -6,6 +6,10 @@ On an machine with Amazon Linux:
 
 On a machine with docker and access to lambci images:
 
-`docker run --rm -v `pwd`:/app lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only mysqlclient 1.3.12"`
+```
+docker run --rm -v `pwd`:/app lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only mysqlclient 1.3.12"
+```
 
-`docker run --rm -v `pwd`:/app lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only mysqlclient 1.3.12"`
+```
+docker run --rm -v `pwd`:/app lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only mysqlclient 1.3.12"
+```

--- a/lambda_packages/mysqlclient/build.sh
+++ b/lambda_packages/mysqlclient/build.sh
@@ -88,8 +88,8 @@ function build_package {
 
     echo "install pips"
     TARGET_DIR=${ENV}/packaged
-    echo ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
-    ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    echo ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
     deactivate
 
     TARGET_DIR=${ENV}/packaged

--- a/lambda_packages/pylibmc/README.md
+++ b/lambda_packages/pylibmc/README.md
@@ -8,6 +8,10 @@ Built based on https://github.com/bxm156/pylibmc-manylinux/blob/master/.travis.y
 
 On a machine with docker and access to lambci images:
 
-`docker run --rm -v `pwd`:/app -d lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only pylibmc 1.5.2"`
+```
+docker run --rm -v `pwd`:/app -d lambci/lambda:build-python2.7 bash -c "cd /app && /app/build.sh --docker --py2-only pylibmc 1.5.2"
+```
 
-`docker run --rm -v `pwd`:/app -d lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only pylibmc 1.5.2"`
+```
+docker run --rm -v `pwd`:/app -d lambci/lambda:build-python3.6 bash -c "cd /app && /app/build.sh --docker --py3-only pylibmc 1.5.2"
+```

--- a/lambda_packages/pylibmc/build.sh
+++ b/lambda_packages/pylibmc/build.sh
@@ -99,8 +99,8 @@ function build_package {
 
     echo "install pips"
     TARGET_DIR=${ENV}/packaged
-    echo ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
-    ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    echo ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
     deactivate
 
     TARGET_DIR=${ENV}/packaged

--- a/lambda_packages/python-ldap/build.sh
+++ b/lambda_packages/python-ldap/build.sh
@@ -88,8 +88,8 @@ function build_package {
 
     echo "install pips"
     TARGET_DIR=${ENV}/packaged
-    echo ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
-    ${PIP} install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    echo ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+    ${PIP} install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
     deactivate
 
     TARGET_DIR=${ENV}/packaged

--- a/lambda_packages/regex/build.sh
+++ b/lambda_packages/regex/build.sh
@@ -39,7 +39,7 @@ echo "activate env in `pwd`"
 source env/bin/activate
 
 echo "install pips"
-pip install --verbose --use-wheel pillow
+pip install --verbose pillow
 deactivate
 
 echo "tar lib and lib64"

--- a/lambda_packages/xmlsec/build.sh
+++ b/lambda_packages/xmlsec/build.sh
@@ -33,7 +33,7 @@ echo 'install-purelib=$base/lib64/python' >> ./setup.cfg
 
 TARGET_DIR=${ENV}/packaged
 echo "install pips"
-pip install --verbose --use-wheel --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
+pip install --verbose --no-dependencies --target ${TARGET_DIR} "${PACKAGE}==${VERSION}"
 deactivate
 
 cp `rpm -ql xmlsec1 | grep "libxmlsec1.so.1$"` ${TARGET_DIR}


### PR DESCRIPTION
* removed the obsolete pip option '--use-wheel' which no longer works.
* fixed formatting of the build instructions in READMEs which made copy-pasting from a formatted page incorrect.